### PR TITLE
Properly unsubscribes component from debouncedDidResize.

### DIFF
--- a/addon/mixins/perfect-scrollbar.js
+++ b/addon/mixins/perfect-scrollbar.js
@@ -15,9 +15,7 @@ export default Mixin.create({
     const resizeService = get(this, 'resizeService');
 
     if (isPresent(resizeService)) {
-      resizeService.on('debouncedDidResize', () => {
-        this._resizePerfectScrollbar();
-      });
+      resizeService.on('debouncedDidResize', this, "_resizePerfectScrollbar");
     }
   },
 
@@ -33,6 +31,12 @@ export default Mixin.create({
 
   willDestroyElement(...args) {
     this._super(...args);
+
+    const resizeService = get(this, 'resizeService');
+
+    if (isPresent(resizeService)) {
+      resizeService.off('debouncedDidResize', this, "_resizePerfectScrollbar");
+    }
 
     PerfectScrollbar.destroy(this.element);
   }


### PR DESCRIPTION
I found that the _resizePerfectScrollbar method was being called on
destroyed components, and this was producing errors. That is because a
component with the mixin was still subscribed to the
“debouncedDidResize” event even after being destroyed. I have added the
proper cleanup code.